### PR TITLE
Prevent infinite recursions on immediately called macro tag

### DIFF
--- a/jinja_macro_tags.py
+++ b/jinja_macro_tags.py
@@ -144,7 +144,7 @@ class LoadMacroExtension(Extension):
         environment.extend(macros=MacroRegistry(environment))
 
     def parse(self, parser):
-        lineno = parser.stream.next().lineno
+        lineno = next(parser.stream).lineno
 
         args = []
         require_comma = False
@@ -178,7 +178,7 @@ class LoadMacroExtension(Extension):
                 templates[tpl].add(name)
 
         imports = []
-        for tpl, macros in templates.iteritems():
+        for tpl, macros in templates.items():
             imports.append(nodes.FromImport(nodes.Const(tpl), macros, True, lineno=lineno))
 
         return imports
@@ -189,9 +189,9 @@ class CallMacroTagExtension(Extension):
 
     def parse(self, parser):
         is_block = parser.stream.current.test("name:call_macro_tag")
-        lineno = parser.stream.next().lineno
+        lineno = next(parser.stream).lineno
         macro_name = self.environment.macros.resolve_alias(parser.stream.current.value)
-        parser.stream.next()
+        next(parser.stream)
         args, kwargs = parse_macro_tag_signature(parser)
 
         call = nodes.Call(nodes.Name(macro_name, "load"), args, kwargs, None, None, lineno=lineno)

--- a/jinja_macro_tags.py
+++ b/jinja_macro_tags.py
@@ -170,8 +170,12 @@ class LoadMacroExtension(Extension):
             name, tpl = self.environment.macros.resolve(arg.name)
             if name is None:
                 continue
-            templates.setdefault(tpl, set())
-            templates[tpl].add(name)
+            if tpl == parser.name:
+                # macro definition is in the same file as macro call, nothing to import
+                pass
+            else:
+                templates.setdefault(tpl, set())
+                templates[tpl].add(name)
 
         imports = []
         for tpl, macros in templates.iteritems():


### PR DESCRIPTION
When macro definition and call-macro-tag are in teh same jinja2 template file, previously the auto-import created an infinite recursion, this patch prevents this.